### PR TITLE
drop deprecated warn argument, it is removed in Ansible 2.14 and prepare for rhel 9.2

### DIFF
--- a/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/assert-installation.yml
@@ -104,8 +104,6 @@
       ansible.builtin.shell: "{{ __sap_general_preconfigure_fact_yum_group_list_installed_command_assert }}"
       register: __sap_general_preconfigure_register_yum_group_assert
       changed_when: no
-      args:
-        warn: false
 
     - name: Assert that all required RHEL 7 package groups are installed
       ansible.builtin.assert:
@@ -135,8 +133,6 @@
       ansible.builtin.shell: "{{ __sap_general_preconfigure_fact_yum_envgroup_list_installed_command_assert }}"
       register: __sap_general_preconfigure_register_yum_envgroup_assert
       changed_when: no
-      args:
-        warn: false
 
     - name: Assert that all required RHEL 8 environment groups are installed
       ansible.builtin.assert:

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -103,7 +103,8 @@
     - sap_general_preconfigure_set_minor_release
     - __sap_general_preconfigure_register_subscription_manager_release.stdout != ansible_distribution_version
 
-- name: Ensure that the required package groups are installed, RHEL 7
+# Reason for noqa: The yum module appears to not support the check-update option
+- name: Ensure that the required package groups are installed, RHEL 7 # noqa command-instead-of-module
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} -y"
   register: __sap_general_preconfigure_register_yum_group_install
   when: ansible_distribution_major_version == '7'
@@ -112,8 +113,9 @@
   ansible.builtin.debug:
     var: __sap_general_preconfigure_register_yum_group_install
   when: ansible_distribution_major_version == '7'
-
-- name: Ensure that the required package groups are installed, RHEL 8 and RHEL 9
+ 
+# Reason for noqa: The yum module appears to not support the check-update option
+- name: Ensure that the required package groups are installed, RHEL 8 and RHEL 9 # noqa command-instead-of-module
 # Note: We want to avoid unwanted package upgrades, see bug 1983749.
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} --nobest --exclude=kernel* -y"
   register: __sap_general_preconfigure_register_yum_group_install

--- a/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/RedHat/installation.yml
@@ -105,8 +105,6 @@
 
 - name: Ensure that the required package groups are installed, RHEL 7
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} -y"
-  args:
-    warn: false
   register: __sap_general_preconfigure_register_yum_group_install
   when: ansible_distribution_major_version == '7'
 
@@ -118,8 +116,6 @@
 - name: Ensure that the required package groups are installed, RHEL 8 and RHEL 9
 # Note: We want to avoid unwanted package upgrades, see bug 1983749.
   ansible.builtin.command: "yum install {{ sap_general_preconfigure_packagegroups | join(' ') }} --nobest --exclude=kernel* -y"
-  args:
-    warn: false
   register: __sap_general_preconfigure_register_yum_group_install
   when: ansible_distribution_major_version == '8' or ansible_distribution_major_version == '9'
 
@@ -228,8 +224,6 @@
   register: __sap_general_preconfigure_register_needs_restarting
   ignore_errors: true
   changed_when: false
-  args:
-    warn: false
   check_mode: false
 
 - name: Display the output of the reboot requirement check

--- a/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/assert-installation.yml
@@ -134,8 +134,6 @@
   ansible.builtin.shell: "{{ __sap_general_preconfigure_fact_needs_restarting_command_assert }}"
   register: __sap_general_preconfigure_register_needs_restarting_assert
   changed_when: false
-  args:
-    warn: false
   check_mode: false
   ignore_errors: "{{ sap_general_preconfigure_assert_ignore_errors | d(false) }}"
 

--- a/roles/sap_general_preconfigure/tasks/SLES/installation.yml
+++ b/roles/sap_general_preconfigure/tasks/SLES/installation.yml
@@ -76,8 +76,6 @@
   register: __sap_general_preconfigure_register_needs_restarting
   ignore_errors: true
   changed_when: false
-  args:
-    warn: false
   check_mode: false
 
 - name: Display the output of the reboot requirement check

--- a/roles/sap_hana_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/assert-installation.yml
@@ -81,12 +81,11 @@
 ### # /opt/ibm/lop/configure
 ### # yum -y install ibm-power-managed-rhel7
 ###
-- name: Get install status of required IBM packages
+# Reason for noqa: The yum module appears to not support the check-update option
+- name: Get install status of required IBM packages # noqa command-instead-of-module
   ansible.builtin.shell: set -o pipefail && yum info installed {{ __sap_hana_preconfigure_required_ppc64le | map('quote') | join(' ') }} | awk '/Name/{n=$NF}/Version/{v=$NF}/Release/{r=$NF}/Description/{printf ("%s\n", n)}'
   register: __sap_hana_preconfigure_register_required_ppc64le_packages_assert
   changed_when: no
-  args:
-    warn: false
 
 - name: Assert that all required IBM packages are installed
   ansible.builtin.assert:
@@ -223,8 +222,6 @@
   ansible.builtin.shell: "{{ __sap_hana_preconfigure_fact_needs_restarting_command_assert }}"
   register: __sap_hana_preconfigure_register_needs_restarting_assert
   changed_when: false
-  args:
-    warn: false
   check_mode: false
   ignore_errors: "{{ sap_hana_preconfigure_assert_ignore_errors | d(false) }}"
 

--- a/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
+++ b/roles/sap_hana_preconfigure/tasks/RedHat/installation.yml
@@ -209,8 +209,6 @@
   register: __sap_hana_preconfigure_register_needs_restarting
   ignore_errors: true
   changed_when: false
-  args:
-    warn: false
   check_mode: false
 
 - name: Display the output of the reboot requirement check

--- a/roles/sap_hana_preconfigure/tasks/sapnote/2292690/10-assert-ibm-energyscale.yml
+++ b/roles/sap_hana_preconfigure/tasks/sapnote/2292690/10-assert-ibm-energyscale.yml
@@ -8,14 +8,12 @@
 - name: Check of package pseries-energy
   when: ansible_architecture == "ppc64le"
   block:
-
-    - name: Check if package pseries-energy is not installed
+    # Reason for noqa: The yum module appears to not support the check-update option
+    - name: Check if package pseries-energy is not installed # noqa command-instead-of-module
       ansible.builtin.command: yum info installed pseries-energy
       register: __sap_hana_preconfigure_register_yum_pseries_energy_assert
       changed_when: no
       ignore_errors: yes
-      args:
-        warn: false
 
     - name: Assert that package pseries-energy is not installed
       ansible.builtin.assert:

--- a/roles/sap_hana_preconfigure/vars/RedHat_9.yml
+++ b/roles/sap_hana_preconfigure/vars/RedHat_9.yml
@@ -25,6 +25,16 @@ __sap_hana_preconfigure_req_repos_redhat_9_1_ppc64le:
   - "rhel-9-for-ppc64le-appstream-rpms"
   - "rhel-9-for-ppc64le-sap-solutions-rpms"
 
+__sap_hana_preconfigure_req_repos_redhat_9_2_x86_64:
+  - "rhel-9-for-x86_64-baseos-rpms"
+  - "rhel-9-for-x86_64-appstream-rpms" 
+  - "rhel-9-for-x86_64-sap-solutions-rpms"
+
+__sap_hana_preconfigure_req_repos_redhat_9_2_ppc64le:
+  - "rhel-9-for-ppc64le-baseos-rpms"
+  - "rhel-9-for-ppc64le-appstream-rpms"
+  - "rhel-9-for-ppc64le-sap-solutions-rpms"
+
 # required SAP notes for RHEL 9:
 __sap_hana_preconfigure_sapnotes_versions_x86_64:
   - { number: '2777782', version: '22' }

--- a/roles/sap_netweaver_preconfigure/tasks/RedHat/assert-installation.yml
+++ b/roles/sap_netweaver_preconfigure/tasks/RedHat/assert-installation.yml
@@ -12,12 +12,11 @@
     loop_var: line_item
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
 
-- name: Check if required packages for Adobe Document Services are installed
+# Reason for noqa: The yum module appears to not support the check-update option
+- name: Check if required packages for Adobe Document Services are installed # noqa command-instead-of-module
   ansible.builtin.shell: rpm -q --qf "%{NAME}.%{ARCH}\n" {{ __sap_netweaver_preconfigure_adobe_doc_services_packages | map('quote') | join(' ') }}
   register: __sap_netweaver_preconfigure_register_rpm_q_ads_packages
   changed_when: no
-  args:
-    warn: false
   when: sap_netweaver_preconfigure_use_adobe_doc_services | d(false)
   ignore_errors: "{{ sap_netweaver_preconfigure_assert_ignore_errors | d(false) }}"
 


### PR DESCRIPTION
Hi Bernd,

could you please have a look? These patches are needed for 9.2.
Thanks